### PR TITLE
Remove NO_TEST flag for cjdns compilation

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -59,7 +59,7 @@ fi
 # Build cjdns
 if ! [ -x "/opt/cjdns/cjdroute" ]; then
     here=`pwd`
-    cd /opt/cjdns && sudo NO_TEST=1 Seccomp_NO=1 NO_NEON=$CJDNS_NO_NEON CFLAGS="$CJDNS_CFLAGS" ./do && cd $here
+    cd /opt/cjdns && sudo Seccomp_NO=1 NO_NEON=$CJDNS_NO_NEON CFLAGS="$CJDNS_CFLAGS" ./do && cd $here
 fi
 
 # Install cjdns to /usr/bin


### PR DESCRIPTION
Seems no longer needed on Pi 3 for cjdns-v18. Need to test on Pi 2.