### PR TITLE
Fix installation instructions with IPFS

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The following instructions will help you set up an encrypted mesh network based 
     To install with all optional features:
 
     ```
-    $ curl -o- https://raw.githubusercontent.com/tomeshnet/prototype-cjdns-pi2/master/scripts/install | WITH_WIFI_AP=true WITH_IPFS=true bash
+    $ wget https://raw.githubusercontent.com/tomeshnet/prototype-cjdns-pi2/master/scripts/install && chmod +x install && WITH_WIFI_AP=true WITH_IPFS=true ./install
     ```
 
 ## Check status


### PR DESCRIPTION
With IPFS install, the script fails after the IPFS unzips.