### PR TITLE
Make install scripts modular and mesh point interface optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,16 @@ The following instructions will help you set up an encrypted mesh network based 
     $ curl -o- https://raw.githubusercontent.com/tomeshnet/prototype-cjdns-pi2/master/scripts/install | bash
     ```
 
-    **Optional:** If you want to install [IPFS](https://ipfs.io), set the `WITH_IPFS` flag to `true`.
+    **Optional:** If you have a TP-LINK TL-WN722N and want to configure it as a [802.11s Mesh Point](https://github.com/o11s/open80211s/wiki/HOWTO) interface, set the `WITH_MESH_POINT` flag to `true`.
 
     **Optional:** If you have a Raspberry Pi 3 and want to configure the on-board WiFi as an Access Point, set the `WITH_WIFI_AP` flag to `true`. The default configuration routes all traffic to the Ethernet port `eth0`. 
+
+    **Optional:** If you want to install [IPFS](https://ipfs.io), set the `WITH_IPFS` flag to `true`.
 
     To install with all optional features:
 
     ```
-    $ wget https://raw.githubusercontent.com/tomeshnet/prototype-cjdns-pi2/master/scripts/install && chmod +x install && WITH_WIFI_AP=true WITH_IPFS=true ./install
+    $ wget https://raw.githubusercontent.com/tomeshnet/prototype-cjdns-pi2/master/scripts/install && chmod +x install && WITH_MESH_POINT=true WITH_WIFI_AP=true WITH_IPFS=true ./install
     ```
 
 ## Check status

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The following instructions will help you set up an encrypted mesh network based 
 1. SSH back in with your new password and run the following, then let the installation complete. After about 5 minutes the Pi will reboot:
 
     ```
-    $ curl -o- https://raw.githubusercontent.com/tomeshnet/prototype-cjdns-pi2/master/scripts/install | bash
+    $ wget https://raw.githubusercontent.com/tomeshnet/prototype-cjdns-pi2/master/scripts/install && chmod +x install && ./install
     ```
 
     **Optional:** If you have a TP-LINK TL-WN722N and want to configure it as a [802.11s Mesh Point](https://github.com/o11s/open80211s/wiki/HOWTO) interface, set the `WITH_MESH_POINT` flag to `true`.

--- a/scripts/hostapd/install
+++ b/scripts/hostapd/install
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+set -e
+
+BASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Install hostapd and dnsmasq to run IEEE 802.11 Access Point
+if ! [ "$(which hostapd)" ] || ! [ "$(dnsmasq)" ]; then
+    sudo apt-get update
+    sudo apt-get install hostapd dnsmasq -y
+fi
+
+# Configure wlan0 interface
+sudo cp /etc/network/interfaces /etc/network/interfaces.backup
+START=$(grep -n "allow-hotplug wlan0" /etc/network/interfaces | awk '{ print $1 }' FS=':')
+END=$(expr $START + 3)
+sudo sed -i "${START},${END}d" /etc/network/interfaces
+echo "" | sudo tee --append /etc/network/interfaces > /dev/null
+echo "allow-hotplug wlan0" | sudo tee --append /etc/network/interfaces > /dev/null
+echo "iface wlan0 inet static" | sudo tee --append /etc/network/interfaces > /dev/null
+echo "    address 10.0.0.1" | sudo tee --append /etc/network/interfaces > /dev/null
+echo "    netmask 255.255.255.0" | sudo tee --append /etc/network/interfaces > /dev/null
+echo "    network 10.0.0.0" | sudo tee --append /etc/network/interfaces > /dev/null
+echo "    broadcast 10.0.0.255" | sudo tee --append /etc/network/interfaces > /dev/null
+
+# Enable packet forwarding
+sudo cp /etc/sysctl.conf /etc/sysctl.conf.backup
+sudo sed -i 's/#net.ipv4.ip_forward=1/net.ipv4.ip_forward=1/' /etc/sysctl.conf
+sudo sed -i 's/#net.ipv6.conf.all.forwarding=1/net.ipv6.conf.all.forwarding=1/' /etc/sysctl.conf
+
+# Get network name and password
+APSSID=$(sudo grep -m 1 '"ipv6"' /etc/cjdroute.conf | awk '{ print $2 }' | sed 's/[",]//g' | sed 's/.*:/tomesh-/g')
+read -p "Set WPA2-PSK password for WiFi Access Point: " APPASS;
+
+# Configure network with hostapd
+sudo cp "$BASE_DIR/hostapd.conf" /etc/hostapd/hostapd.conf
+sudo echo "ssid=$APSSID" | sudo tee --append /etc/hostapd/hostapd.conf > /dev/null
+sudo echo "wpa_passphrase=$APPASS" | sudo tee --append /etc/hostapd/hostapd.conf > /dev/null
+
+# Configure DHCP with dnsmasq
+sudo cp /etc/dnsmasq.conf /etc/dnsmasq.conf.backup
+sudo cp "$BASE_DIR/dnsmasq.conf" /etc/dnsmasq.conf
+sudo cp /etc/dhcpcd.conf /etc/dhcpcd.conf.backup
+sudo echo "" | sudo tee --append /etc/dhcpcd.conf > /dev/null
+sudo echo "denyinterfaces wlan0" | sudo tee --append /etc/dhcpcd.conf > /dev/null
+
+# Enable hostapd service
+sudo cp "$BASE_DIR/hostapd.service" /etc/systemd/system/hostapd.service
+sudo systemctl enable hostapd

--- a/scripts/hostapd/install
+++ b/scripts/hostapd/install
@@ -30,7 +30,9 @@ sudo sed -i 's/#net.ipv6.conf.all.forwarding=1/net.ipv6.conf.all.forwarding=1/' 
 
 # Get network name and password
 APSSID=$(sudo grep -m 1 '"ipv6"' /etc/cjdroute.conf | awk '{ print $2 }' | sed 's/[",]//g' | sed 's/.*:/tomesh-/g')
-read -p "Set WPA2-PSK password for WiFi Access Point: " APPASS;
+while [ "${#APPASS}" -lt 8 ] || [ "${#APPASS}" -gt 63 ]; do
+    read -p "Set WPA2-PSK password for WiFi Access Point (8-63 characters): " APPASS;
+done
 
 # Configure network with hostapd
 sudo cp "$BASE_DIR/hostapd.conf" /etc/hostapd/hostapd.conf

--- a/scripts/hostapd/uninstall
+++ b/scripts/hostapd/uninstall
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Uninstall WiFi Access Point
+sudo systemctl disable hostapd.service 2>/dev/null
+sudo systemctl stop hostapd.service 2>/dev/null || true
+if [ -f "/etc/network/interfaces.backup" ]; then
+    sudo mv /etc/network/interfaces.backup /etc/network/interfaces
+fi
+if [ -f "/etc/sysctl.conf.backup" ]; then
+    sudo mv /etc/sysctl.conf.backup /etc/sysctl.conf
+fi
+if [ -f "/etc/dnsmasq.conf.backup" ]; then
+    sudo mv /etc/dnsmasq.conf.backup /etc/dnsmasq.conf
+fi
+if [ -f "/etc/dhcpcd.conf.backup" ]; then
+    sudo mv /etc/dhcpcd.conf.backup /etc/dhcpcd.conf
+fi
+sudo rm -f /etc/hostapd/hostapd.conf
+sudo rm -f /etc/systemd/system/hostapd.service

--- a/scripts/install
+++ b/scripts/install
@@ -2,9 +2,8 @@
 
 set -e
 
-TAG_PROTOTYPE_CJDNS_PI2=master
+TAG_PROTOTYPE_CJDNS_PI2=modular
 TAG_CJDNS=cjdns-v18
-GO_IPFS_VERSION=v0.4.2
 
 # Get RPi version and set flags accordingly
 RPI_REVISION=`sed -rn 's/Revision\s+\:\s+([0-9a-z_\-\s\,\(\)]+)/\1/p' /proc/cpuinfo`
@@ -21,11 +20,43 @@ elif [[ $RPI_REVISION == *"00"* ]]; then
     echo ">>> Starting installation on Raspberry Pi 1..."
 elif [[ $RPI_REVISION == *"a01041"* || $RPI_REVISION == *"a21041"* ]]; then
     echo ">>> Starting installation on Raspberry Pi 2..."
-elif [[ $RPI_REVISION == *"a02082"* || $RPI_REVISION = *"a22082"* ]]; then
+elif [[ $RPI_REVISION == *"a02082"* || $RPI_REVISION == *"a22082"* ]]; then
     echo ">>> Starting installation on Raspberry Pi 3..."
 else
     echo ">>> Unknown Raspberry Pi model"
     exit 1
+fi
+
+# Prompt and set missing flags
+if [ -z "$WITH_MESH_POINT" -o "$WITH_MESH_POINT" != "true" -a "$WITH_MESH_POINT" != "false" ]; then
+    read -p "Configure Mesh Point interface (Y/n)? " CHOICE_MESH_POINT;
+    if [ "$CHOICE_MESH_POINT" == "Y" ]; then
+        echo -e "\e[1;32mMesh Point interface will be configured\e[0m"
+        WITH_MESH_POINT=true
+    else
+        echo -e "\e[1;31mMesh Point interface configuration will be skipped\e[0m"
+        WITH_MESH_POINT=false
+    fi
+fi
+if [[ $RPI_REVISION == *"a02082"* || $RPI_REVISION == *"a22082"* ]] && [ -z "$WITH_WIFI_AP" -o "$WITH_WIFI_AP" != "true" -a "$WITH_WIFI_AP" != "false" ]; then
+    read -p "Configure WiFi Access Point (Y/n)? " CHOICE_WIFI_AP;
+    if [ "$CHOICE_WIFI_AP" == "Y" ]; then
+        echo -e "\e[1;32mWiFi Access Point will be configured\e[0m"
+        WITH_WIFI_AP=true
+    else
+        echo -e "\e[1;31mWiFi Access Point configuration will be skipped\e[0m"
+        WITH_WIFI_AP=false
+    fi
+fi
+if [ -z "$WITH_IPFS" -o "$WITH_IPFS" != "true" -a "$WITH_IPFS" != "false" ]; then
+    read -p "Install IPFS (Y/n)? " CHOICE_IPFS;
+    if [ "$CHOICE_IPFS" == "Y" ]; then
+        echo -e "\e[1;32mIPFS will be installed\e[0m"
+        WITH_IPFS=true
+    else
+        echo -e "\e[1;31mIPFS installation will be skipped\e[0m"
+        WITH_IPFS=false
+    fi
 fi
 
 # Get tools
@@ -39,15 +70,6 @@ if ! [ -d "prototype-cjdns-pi2" ]; then
     git clone https://github.com/tomeshnet/prototype-cjdns-pi2.git
     cd prototype-cjdns-pi2 && git checkout $TAG_PROTOTYPE_CJDNS_PI2 && cd ..
 fi
-
-# Install bring-up script for the Mesh Point interface to /usr/bin
-sudo cp prototype-cjdns-pi2/scripts/mesh-point/mesh /usr/bin/mesh
-
-# Configure systemd to start mesh.service on system boot
-sudo cp prototype-cjdns-pi2/scripts/mesh-point/mesh.service /lib/systemd/system/mesh.service
-sudo chmod 644 /lib/systemd/system/mesh.service
-sudo systemctl daemon-reload
-sudo systemctl enable mesh.service
 
 # Download cjdns repo and checkout TAG_CJDNS tag
 if ! [ -d "/opt/cjdns" ]; then
@@ -80,66 +102,19 @@ sudo chmod 644 /lib/systemd/system/cjdns-resume.service
 sudo systemctl daemon-reload
 sudo systemctl enable cjdns.service
 
+# 802.11s Mesh Point interface
+if [ ! -z "$WITH_MESH_POINT" -a "$WITH_MESH_POINT" = "true" ]; then
+    source prototype-cjdns-pi2/scripts/mesh-point/install
+fi
+
 # WiFi Access Point on RPi3
-if [[ $RPI_REVISION == *"a02082"* || $RPI_REVISION = *"a22082"* ]] && [ ! -z "$WITH_WIFI_AP" -a "$WITH_WIFI_AP" = "true" ]; then
-    # Install hostapd and dnsmasq to run IEEE 802.11 Access Point
-    if ! [ "$(which hostapd)" ] || ! [ "$(dnsmasq)" ]; then
-        sudo apt-get update
-        sudo apt-get install hostapd dnsmasq -y
-    fi
-
-    # Configure wlan0 interface
-    sudo cp /etc/network/interfaces /etc/network/interfaces.backup
-    START=$(grep -n "allow-hotplug wlan0" /etc/network/interfaces | awk '{ print $1 }' FS=':')
-    END=$(expr $START + 3)
-    sudo sed -i "${START},${END}d" /etc/network/interfaces
-    echo "" | sudo tee --append /etc/network/interfaces > /dev/null
-    echo "allow-hotplug wlan0" | sudo tee --append /etc/network/interfaces > /dev/null
-    echo "iface wlan0 inet static" | sudo tee --append /etc/network/interfaces > /dev/null
-    echo "    address 10.0.0.1" | sudo tee --append /etc/network/interfaces > /dev/null
-    echo "    netmask 255.255.255.0" | sudo tee --append /etc/network/interfaces > /dev/null
-    echo "    network 10.0.0.0" | sudo tee --append /etc/network/interfaces > /dev/null
-    echo "    broadcast 10.0.0.255" | sudo tee --append /etc/network/interfaces > /dev/null
-
-    # Enable packet forwarding
-    sudo cp /etc/sysctl.conf /etc/sysctl.conf.backup
-    sudo sed -i 's/#net.ipv4.ip_forward=1/net.ipv4.ip_forward=1/' /etc/sysctl.conf
-    sudo sed -i 's/#net.ipv6.conf.all.forwarding=1/net.ipv6.conf.all.forwarding=1/' /etc/sysctl.conf
-
-    # Get network name and password
-    APSSID=$(sudo grep -m 1 '"ipv6"' /etc/cjdroute.conf | awk '{ print $2 }' | sed 's/[",]//g' | sed 's/.*:/tomesh-/g')
-    read -p "Set WPA2-PSK password for WiFi Access Point: " APPASS;
-
-    # Configure network with hostapd
-    sudo cp prototype-cjdns-pi2/scripts/hostapd/hostapd.conf /etc/hostapd/hostapd.conf
-    sudo echo "ssid=$APSSID" | sudo tee --append /etc/hostapd/hostapd.conf > /dev/null
-    sudo echo "wpa_passphrase=$APPASS" | sudo tee --append /etc/hostapd/hostapd.conf > /dev/null
-
-    # Configure DHCP with dnsmasq
-    sudo cp /etc/dnsmasq.conf /etc/dnsmasq.conf.backup
-    sudo cp prototype-cjdns-pi2/scripts/hostapd/dnsmasq.conf /etc/dnsmasq.conf
-    sudo cp /etc/dhcpcd.conf /etc/dhcpcd.conf.backup
-    sudo echo "" | sudo tee --append /etc/dhcpcd.conf > /dev/null
-    sudo echo "denyinterfaces wlan0" | sudo tee --append /etc/dhcpcd.conf > /dev/null
-
-    # Enable hostapd service
-    sudo cp prototype-cjdns-pi2/scripts/hostapd/hostapd.service /etc/systemd/system/hostapd.service
-    sudo systemctl enable hostapd
+if [[ $RPI_REVISION == *"a02082"* || $RPI_REVISION == *"a22082"* ]] && [ ! -z "$WITH_WIFI_AP" -a "$WITH_WIFI_AP" = "true" ]; then
+    source prototype-cjdns-pi2/scripts/hostapd/install
 fi
 
 # IPFS
 if [ ! -x "$(command -v ipfs)" ] && [ ! -z "$WITH_IPFS" -a "$WITH_IPFS" = "true" ]; then
-    # Install and initialize IPFS
-    wget "https://dist.ipfs.io/go-ipfs/${GO_IPFS_VERSION}/go-ipfs_${GO_IPFS_VERSION}_linux-arm.tar.gz" -O go-ipfs.tar.gz
-    tar xvfz go-ipfs.tar.gz
-    sudo cp go-ipfs/ipfs /usr/local/bin/ipfs
-    sudo chown root:staff /usr/local/bin/ipfs
-    ipfs init
-
-    # Configure systemd to start ipfs-daemon.service on system boot
-    sudo cp prototype-cjdns-pi2/scripts/ipfs/ipfs-daemon.service /lib/systemd/system/ipfs-daemon.service
-    sudo systemctl daemon-reload
-    sudo systemctl enable ipfs-daemon.service
+    source prototype-cjdns-pi2/scripts/ipfs/install
 fi
 
 # Reboot device

--- a/scripts/install
+++ b/scripts/install
@@ -29,33 +29,36 @@ fi
 
 # Prompt and set missing flags
 if [ -z "$WITH_MESH_POINT" -o "$WITH_MESH_POINT" != "true" -a "$WITH_MESH_POINT" != "false" ]; then
-    read -p "Configure Mesh Point interface (Y/n)? " CHOICE_MESH_POINT;
-    if [ "$CHOICE_MESH_POINT" == "Y" ]; then
-        echo -e "\e[1;32mMesh Point interface will be configured\e[0m"
-        WITH_MESH_POINT=true
-    else
+    read -p "Configure Mesh Point interface (Y/n)? " -n 1 -r
+    echo ""
+    if [[ $REPLY =~ ^[Nn]$ ]]; then
         echo -e "\e[1;31mMesh Point interface configuration will be skipped\e[0m"
         WITH_MESH_POINT=false
+    else
+        echo -e "\e[1;32mMesh Point interface will be configured\e[0m"
+        WITH_MESH_POINT=true
     fi
 fi
 if [[ $RPI_REVISION == *"a02082"* || $RPI_REVISION == *"a22082"* ]] && [ -z "$WITH_WIFI_AP" -o "$WITH_WIFI_AP" != "true" -a "$WITH_WIFI_AP" != "false" ]; then
-    read -p "Configure WiFi Access Point (Y/n)? " CHOICE_WIFI_AP;
-    if [ "$CHOICE_WIFI_AP" == "Y" ]; then
-        echo -e "\e[1;32mWiFi Access Point will be configured\e[0m"
-        WITH_WIFI_AP=true
-    else
+    read -p "Configure WiFi Access Point (Y/n)? " -n 1 -r
+    echo ""
+    if [[ $REPLY =~ ^[Nn]$ ]]; then
         echo -e "\e[1;31mWiFi Access Point configuration will be skipped\e[0m"
         WITH_WIFI_AP=false
+    else
+        echo -e "\e[1;32mWiFi Access Point will be configured\e[0m"
+        WITH_WIFI_AP=true
     fi
 fi
 if [ -z "$WITH_IPFS" -o "$WITH_IPFS" != "true" -a "$WITH_IPFS" != "false" ]; then
-    read -p "Install IPFS (Y/n)? " CHOICE_IPFS;
-    if [ "$CHOICE_IPFS" == "Y" ]; then
-        echo -e "\e[1;32mIPFS will be installed\e[0m"
-        WITH_IPFS=true
-    else
+    read -p "Install IPFS (Y/n)? " -n 1 -r
+    echo ""
+    if [[ $REPLY =~ ^[Nn]$ ]]; then
         echo -e "\e[1;31mIPFS installation will be skipped\e[0m"
         WITH_IPFS=false
+    else
+        echo -e "\e[1;32mIPFS will be installed\e[0m"
+        WITH_IPFS=true
     fi
 fi
 

--- a/scripts/install
+++ b/scripts/install
@@ -103,17 +103,17 @@ sudo systemctl daemon-reload
 sudo systemctl enable cjdns.service
 
 # 802.11s Mesh Point interface
-if [ ! -z "$WITH_MESH_POINT" -a "$WITH_MESH_POINT" = "true" ]; then
+if [ ! -z "$WITH_MESH_POINT" -a "$WITH_MESH_POINT" == "true" ]; then
     source prototype-cjdns-pi2/scripts/mesh-point/install
 fi
 
 # WiFi Access Point on RPi3
-if [[ $RPI_REVISION == *"a02082"* || $RPI_REVISION == *"a22082"* ]] && [ ! -z "$WITH_WIFI_AP" -a "$WITH_WIFI_AP" = "true" ]; then
+if [[ $RPI_REVISION == *"a02082"* || $RPI_REVISION == *"a22082"* ]] && [ ! -z "$WITH_WIFI_AP" -a "$WITH_WIFI_AP" == "true" ]; then
     source prototype-cjdns-pi2/scripts/hostapd/install
 fi
 
 # IPFS
-if [ ! -x "$(command -v ipfs)" ] && [ ! -z "$WITH_IPFS" -a "$WITH_IPFS" = "true" ]; then
+if [ ! -x "$(command -v ipfs)" ] && [ ! -z "$WITH_IPFS" -a "$WITH_IPFS" == "true" ]; then
     source prototype-cjdns-pi2/scripts/ipfs/install
 fi
 

--- a/scripts/install
+++ b/scripts/install
@@ -2,7 +2,7 @@
 
 set -e
 
-TAG_PROTOTYPE_CJDNS_PI2=modular
+TAG_PROTOTYPE_CJDNS_PI2=master
 TAG_CJDNS=cjdns-v18
 
 # Get RPi version and set flags accordingly

--- a/scripts/ipfs/install
+++ b/scripts/ipfs/install
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -e
+
+GO_IPFS_VERSION=v0.4.2
+
+BASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Download and install IPFS
+mkdir "$BASE_DIR/tmp"
+wget "https://dist.ipfs.io/go-ipfs/${GO_IPFS_VERSION}/go-ipfs_${GO_IPFS_VERSION}_linux-arm.tar.gz" -O "$BASE_DIR/tmp/go-ipfs.tar.gz"
+tar xvfz "$BASE_DIR/tmp/go-ipfs.tar.gz" -C "$BASE_DIR/tmp"
+sudo cp "$BASE_DIR/tmp/go-ipfs/ipfs" /usr/local/bin/ipfs
+sudo chown root:staff /usr/local/bin/ipfs
+rm -rf "$BASE_DIR/tmp"
+
+# Initialize IPFS
+ipfs init
+
+# Configure systemd to start ipfs-daemon.service on system boot
+sudo cp "$BASE_DIR/ipfs-daemon.service" /lib/systemd/system/ipfs-daemon.service
+sudo systemctl daemon-reload
+sudo systemctl enable ipfs-daemon.service

--- a/scripts/ipfs/uninstall
+++ b/scripts/ipfs/uninstall
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Uninstall IPFS
+sudo systemctl disable ipfs-daemon.service
+sudo systemctl stop ipfs-daemon.service 2>/dev/null || true
+sudo rm -f /usr/local/bin/ipfs
+sudo rm -f /lib/systemd/system/ipfs-daemon.service
+
+if [ -d "/home/pi/.ipfs" ]; then
+    echo "Found /home/pi/.ipfs"
+    read -p "Remove your IPFS data (Y/n)? " RM_IPFS_HOME;
+    if [ "$RM_IPFS_HOME" == "Y" ]; then
+        echo "Removing /home/pi/.ipfs"
+        rm -rf /home/pi/.ipfs
+    else
+        echo "Keeping /home/pi/.ipfs"
+    fi
+fi

--- a/scripts/ipfs/uninstall
+++ b/scripts/ipfs/uninstall
@@ -10,11 +10,12 @@ sudo rm -f /lib/systemd/system/ipfs-daemon.service
 
 if [ -d "/home/pi/.ipfs" ]; then
     echo "Found /home/pi/.ipfs"
-    read -p "Remove your IPFS data (Y/n)? " RM_IPFS_HOME;
-    if [ "$RM_IPFS_HOME" == "Y" ]; then
-        echo "Removing /home/pi/.ipfs"
+    read -p "Keep your IPFS data (Y/n)? " -n 1 -r
+    echo ""
+    if [[ $REPLY =~ ^[Nn]$ ]]; then
+        echo -e "\e[1;31mRemoving /home/pi/.ipfs\e[0m"
         rm -rf /home/pi/.ipfs
     else
-        echo "Keeping /home/pi/.ipfs"
+        echo -e "\e[1;31mKeeping /home/pi/.ipfs\e[0m"
     fi
 fi

--- a/scripts/mesh-point/install
+++ b/scripts/mesh-point/install
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -e
+
+BASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Install bring-up script for the Mesh Point interface to /usr/bin
+sudo cp "$BASE_DIR/mesh" /usr/bin/mesh
+
+# Configure systemd to start mesh.service on system boot
+sudo cp "$BASE_DIR/mesh.service" /lib/systemd/system/mesh.service
+sudo chmod 644 /lib/systemd/system/mesh.service
+sudo systemctl daemon-reload
+sudo systemctl enable mesh.service

--- a/scripts/mesh-point/uninstall
+++ b/scripts/mesh-point/uninstall
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Uninstall Mesh Point interface
+sudo systemctl disable mesh.service 2>/dev/null
+sudo rm -f /usr/bin/mesh
+sudo rm -f /lib/systemd/system/mesh.service

--- a/scripts/status
+++ b/scripts/status
@@ -10,15 +10,17 @@ echo "  | || (_) | | | | | |  __\__ | | | |"
 echo "   \__\___/|_| |_| |_|\___|___|_| |_|"
 
 echo -e '---------------------------------------'
-if [ "$(iw dev mesh0 info 2>/dev/null | grep 'type mesh point')" ] && [ "$(iw dev mesh0 info 2>/dev/null | grep 'channel')" ]; then
-    echo -e "Mesh Interface ............... $ACTIVE"
-else
-    echo -e "Mesh Interface ............. $INACTIVE"
-fi
 if [ $(systemctl status cjdns.service | grep 'Active: ' | awk '{ print $2 }') = 'active' ]; then
     echo -e "cjdns Service ................ $ACTIVE"
 else
     echo -e "cjdns Service .............. $INACTIVE"
+fi
+if [ "$(which mesh)" ]; then
+    if [ "$(iw dev mesh0 info 2>/dev/null | grep 'type mesh point')" ] && [ "$(iw dev mesh0 info 2>/dev/null | grep 'channel')" ]; then
+        echo -e "Mesh Interface ............... $ACTIVE"
+    else
+        echo -e "Mesh Interface ............. $INACTIVE"
+    fi
 fi
 if [ "$(which hostapd)" ]; then
     if [ $(systemctl status hostapd.service | grep 'Active: ' | awk '{ print $2 }') = 'active' ]; then

--- a/scripts/uninstall
+++ b/scripts/uninstall
@@ -14,12 +14,13 @@ sudo rm -rf /opt/cjdns
 
 if [ -f "/etc/cjdroute.conf" ]; then
     echo "Found /etc/cjdroute.conf"
-    read -p "Remove your cjdns identity (Y/n)? " RM_CJDNS_CONF;
-    if [ "$RM_CJDNS_CONF" == "Y" ]; then
-        echo "Removing /etc/cjdroute.conf"
+    read -p "Keep your cjdns identity (Y/n)? " -n 1 -r
+    echo ""
+    if [[ $REPLY =~ ^[Nn]$ ]]; then
+        echo -e "\e[1;31mRemoving /etc/cjdroute.conf\e[0m"
         sudo rm -f /etc/cjdroute.conf
     else
-        echo "Keeping /etc/cjdroute.conf"
+        echo -e "\e[1;32mKeeping /etc/cjdroute.conf\e[0m"
     fi
 fi
 

--- a/scripts/uninstall
+++ b/scripts/uninstall
@@ -2,10 +2,7 @@
 
 set -e
 
-# Uninstall Mesh Point interface
-sudo systemctl disable mesh.service 2>/dev/null
-sudo rm -f /usr/bin/mesh
-sudo rm -f /lib/systemd/system/mesh.service
+BASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Uninstall cjdns
 sudo systemctl disable cjdns.service 2>/dev/null
@@ -26,39 +23,9 @@ if [ -f "/etc/cjdroute.conf" ]; then
     fi
 fi
 
-# Uninstall WiFi Access Point
-sudo systemctl disable hostapd.service 2>/dev/null
-sudo systemctl stop hostapd.service 2>/dev/null || true
-if [ -f "/etc/network/interfaces.backup" ]; then
-    sudo mv /etc/network/interfaces.backup /etc/network/interfaces
-fi
-if [ -f "/etc/sysctl.conf.backup" ]; then
-    sudo mv /etc/sysctl.conf.backup /etc/sysctl.conf
-fi
-if [ -f "/etc/dnsmasq.conf.backup" ]; then
-    sudo mv /etc/dnsmasq.conf.backup /etc/dnsmasq.conf
-fi
-if [ -f "/etc/dhcpcd.conf.backup" ]; then
-    sudo mv /etc/dhcpcd.conf.backup /etc/dhcpcd.conf
-fi
-sudo rm -f /etc/hostapd/hostapd.conf
-sudo rm -f /etc/systemd/system/hostapd.service
-
-# Uninstall IPFS
-sudo systemctl disable ipfs-daemon.service
-sudo systemctl stop ipfs-daemon.service 2>/dev/null || true
-sudo rm -f /usr/local/bin/ipfs
-sudo rm -f /lib/systemd/system/ipfs-daemon.service
-
-if [ -d "/home/pi/.ipfs" ]; then
-    echo "Found /home/pi/.ipfs"
-    read -p "Remove your IPFS data (Y/n)? " RM_IPFS_HOME;
-    if [ "$RM_IPFS_HOME" == "Y" ]; then
-        echo "Removing /home/pi/.ipfs"
-        rm -rf /home/pi/.ipfs
-    else
-        echo "Keeping /home/pi/.ipfs"
-    fi
-fi
+# Uninstall optional modules
+source "$BASE_DIR/mesh-point/uninstall"
+source "$BASE_DIR/hostapd/uninstall"
+source "$BASE_DIR/ipfs/uninstall"
 
 sudo systemctl daemon-reload


### PR DESCRIPTION
This breaks up the monolithic install/uninstall script into modular scripts in each of the optional modules:

- Mesh Point interface _(newly made optional)_
- WiFi Access Point
- IPFS

The install script for each module can now be run standalone after initial installation. This PR also addresses https://github.com/tomeshnet/prototype-cjdns-pi2/issues/38 and part of https://github.com/tomeshnet/prototype-cjdns-pi2/issues/33.