### PR TITLE
NAT66 all local IPv6 traffic to cjdns network interface

### DIFF
--- a/scripts/hostapd/hostapd.service
+++ b/scripts/hostapd/hostapd.service
@@ -7,7 +7,7 @@ BindsTo=sys-subsystem-net-devices-wlan0.device
 Type=forking
 PIDFile=/var/run/hostapd.pid
 ExecStart=/usr/sbin/hostapd -B /etc/hostapd/hostapd.conf -P /var/run/hostapd.pid
-ExecStartPost=/bin/sh -c "exec iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE"
+ExecStartPost=/bin/sh /etc/hostapd/nat.sh
 
 [Install]
 WantedBy=multi-user.target

--- a/scripts/hostapd/install
+++ b/scripts/hostapd/install
@@ -7,7 +7,7 @@ BASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Install hostapd and dnsmasq to run IEEE 802.11 Access Point
 if ! [ "$(which hostapd)" ] || ! [ "$(dnsmasq)" ]; then
     sudo apt-get update
-    sudo apt-get install hostapd dnsmasq -y
+    sudo apt-get install hostapd dnsmasq radvd -y
 fi
 
 # Configure wlan0 interface
@@ -22,6 +22,9 @@ echo "    address 10.0.0.1" | sudo tee --append /etc/network/interfaces > /dev/n
 echo "    netmask 255.255.255.0" | sudo tee --append /etc/network/interfaces > /dev/null
 echo "    network 10.0.0.0" | sudo tee --append /etc/network/interfaces > /dev/null
 echo "    broadcast 10.0.0.255" | sudo tee --append /etc/network/interfaces > /dev/null
+echo "iface wlan0 inet6 static" | sudo tee --append /etc/network/interfaces > /dev/null
+echo "    address fdfc::2" | sudo tee --append /etc/network/interfaces > /dev/null
+echo "    netmask 64" | sudo tee --append /etc/network/interfaces > /dev/null
 
 # Enable packet forwarding
 sudo cp /etc/sysctl.conf /etc/sysctl.conf.backup
@@ -35,6 +38,7 @@ while [ "${#APPASS}" -lt 8 ] || [ "${#APPASS}" -gt 63 ]; do
 done
 
 # Configure network with hostapd
+sudo cp "$BASE_DIR/nat.sh" /etc/hostapd/nat.sh
 sudo cp "$BASE_DIR/hostapd.conf" /etc/hostapd/hostapd.conf
 sudo echo "ssid=$APSSID" | sudo tee --append /etc/hostapd/hostapd.conf > /dev/null
 sudo echo "wpa_passphrase=$APPASS" | sudo tee --append /etc/hostapd/hostapd.conf > /dev/null
@@ -45,6 +49,9 @@ sudo cp "$BASE_DIR/dnsmasq.conf" /etc/dnsmasq.conf
 sudo cp /etc/dhcpcd.conf /etc/dhcpcd.conf.backup
 sudo echo "" | sudo tee --append /etc/dhcpcd.conf > /dev/null
 sudo echo "denyinterfaces wlan0" | sudo tee --append /etc/dhcpcd.conf > /dev/null
+
+# Configure IPv6 router advertisement with radvd
+sudo cp "$BASE_DIR/radvd.conf" /etc/radvd.conf
 
 # Enable hostapd service
 sudo cp "$BASE_DIR/hostapd.service" /etc/systemd/system/hostapd.service

--- a/scripts/hostapd/nat.sh
+++ b/scripts/hostapd/nat.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Forward all IPv4 traffic from the internal network to the eth0 device and mask with the eth0 external IP address
+iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE
+
+# Forward all IPv6 traffic from the internal network to the tun0 device and mask with the tun0 external IP address
+ip6tables -t nat -A POSTROUTING -o tun0 -j MASQUERADE

--- a/scripts/hostapd/radvd.conf
+++ b/scripts/hostapd/radvd.conf
@@ -1,0 +1,9 @@
+interface wlan0 {
+    AdvSendAdvert on;
+    MaxRtrAdvInterval 30;
+    prefix fdfc::/64
+    {
+        AdvOnLink on;
+        AdvAutonomous on;
+    };
+};

--- a/scripts/hostapd/uninstall
+++ b/scripts/hostapd/uninstall
@@ -17,5 +17,7 @@ fi
 if [ -f "/etc/dhcpcd.conf.backup" ]; then
     sudo mv /etc/dhcpcd.conf.backup /etc/dhcpcd.conf
 fi
+sudo rm -f /etc/radvd.conf
 sudo rm -f /etc/hostapd/hostapd.conf
+sudo rm -f /etc/hostapd/nat.sh
 sudo rm -f /etc/systemd/system/hostapd.service


### PR DESCRIPTION
Allow all client devices connected to local AP to access Hyperboria resources via NAT66. This addresses https://github.com/tomeshnet/prototype-cjdns-pi2/issues/46