### PR TITLE
NO_TEST when building for RPi 1

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -84,7 +84,11 @@ fi
 # Build cjdns
 if ! [ -x "/opt/cjdns/cjdroute" ]; then
     here=`pwd`
-    cd /opt/cjdns && sudo Seccomp_NO=1 NO_NEON=$CJDNS_NO_NEON CFLAGS="$CJDNS_CFLAGS" ./do && cd $here
+    if [[ $RPI_REVISION == *"00"* ]]; then
+        cd /opt/cjdns && sudo NO_TEST=1 Seccomp_NO=1 NO_NEON=$CJDNS_NO_NEON CFLAGS="$CJDNS_CFLAGS" ./do && cd $here
+    else
+        cd /opt/cjdns && sudo Seccomp_NO=1 NO_NEON=$CJDNS_NO_NEON CFLAGS="$CJDNS_CFLAGS" ./do && cd $here
+    fi
 fi
 
 # Install cjdns to /usr/bin


### PR DESCRIPTION
Add condition to use NO_TEST var for RPi 1. Otherwise the RPi 1 fails tests on build. Apparantly this variable can be equal to 0/1 and the build process does not perform tests. Looking at cjdns code, I believe just the presence of NO_TEST is enough to ignore tests, and we don't want that for other RPi revisions.