### PR TITLE
NO_TEST when building for RPi 1

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -9,6 +9,7 @@ TAG_CJDNS=cjdns-v18
 RPI_REVISION=`sed -rn 's/Revision\s+\:\s+([0-9a-z_\-\s\,\(\)]+)/\1/p' /proc/cpuinfo`
 CJDNS_CFLAGS="-s -static -Wall -mfpu=neon -mcpu=cortex-a7 -mtune=cortex-a7 -fomit-frame-pointer -marm"
 CJDNS_NO_NEON=0
+CJDNS_NO_TEST=""
 
 if [[ $RPI_REVISION == *"900092"* ]]; then
     echo ">>> This Raspberry Pi model (zero) is not supported"
@@ -17,6 +18,7 @@ elif [[ $RPI_REVISION == *"00"* ]]; then
     # Skip optimizations and ARM Neon when building cjdns
     CJDNS_CFLAGS="-s -static -Wall"
     CJDNS_NO_NEON=1
+    CJDNS_NO_TEST="NO_TEST=1"
     echo ">>> Starting installation on Raspberry Pi 1..."
 elif [[ $RPI_REVISION == *"a01041"* || $RPI_REVISION == *"a21041"* ]]; then
     echo ">>> Starting installation on Raspberry Pi 2..."
@@ -84,11 +86,7 @@ fi
 # Build cjdns
 if ! [ -x "/opt/cjdns/cjdroute" ]; then
     here=`pwd`
-    if [[ $RPI_REVISION == *"00"* ]]; then
-        cd /opt/cjdns && sudo NO_TEST=1 Seccomp_NO=1 NO_NEON=$CJDNS_NO_NEON CFLAGS="$CJDNS_CFLAGS" ./do && cd $here
-    else
-        cd /opt/cjdns && sudo Seccomp_NO=1 NO_NEON=$CJDNS_NO_NEON CFLAGS="$CJDNS_CFLAGS" ./do && cd $here
-    fi
+    cd /opt/cjdns && sudo eval $CJDNS_NO_TEST Seccomp_NO=1 NO_NEON=$CJDNS_NO_NEON CFLAGS="$CJDNS_CFLAGS" ./do && cd $here
 fi
 
 # Install cjdns to /usr/bin

--- a/scripts/install
+++ b/scripts/install
@@ -84,7 +84,11 @@ fi
 # Build cjdns
 if ! [ -x "/opt/cjdns/cjdroute" ]; then
     here=`pwd`
-    cd /opt/cjdns && sudo Seccomp_NO=1 NO_NEON=$CJDNS_NO_NEON CFLAGS="$CJDNS_CFLAGS" ./do && cd $here
+    if [[ $RPI_REVISION == *"00"* ]]; then
+        cd /opt/cjdns && sudo NO_TEST=1 Seccomp_NO=1 NO_NEON=$CJDNS_NO_NEON CFLAGS="$CJDNS_CFLAGS" ./do && cd $here
+    else
+        cd /opt/cjdns && sudo Seccomp_NO=1 NO_NEON=$CJDNS_NO_NEON CFLAGS="$CJDNS_CFLAGS" ./do && cd $here
+    fi
 fi
 
 # Install cjdns to /usr/bin

--- a/scripts/install
+++ b/scripts/install
@@ -15,7 +15,7 @@ if [[ $RPI_REVISION == *"900092"* ]]; then
     echo ">>> This Raspberry Pi model (zero) is not supported"
     exit 0
 elif [[ $RPI_REVISION == *"00"* ]]; then
-    # Skip optimizations and ARM Neon when building cjdns
+    # Skip optimizations, ARM Neon, and tests when building cjdns
     CJDNS_CFLAGS="-s -static -Wall"
     CJDNS_NO_NEON=1
     CJDNS_NO_TEST="NO_TEST=1"


### PR DESCRIPTION
Redid my last PR to reduce duplication in cjdns build commands.

This change sets a variable to "" that gets assigned "NO_TEST=1" if we are building for the RPI 1 as it needs tests to turn off. Simply having NO_TEST equal to anything will cause tests to be ignored, so we cant toggle it with a value of 0/1 or anything. Echoing our var seems to work beautifully whether it contains NO_TEST=1 or of it is empty.